### PR TITLE
Sendmax

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,6 +55,7 @@ program
     .option('-m, --moments [moments]', 'Life moments')
     .option('-c, --contract-id [contract-id]', 'Contract id')
     .option('-i, --image [image]', 'Instance image')
+    .option('-s, --sendmax [evr]', 'Maximum EVR allowed for acquiring the instance')
     .action(acquire);
 
 program
@@ -97,6 +98,7 @@ program
     .option('-m, --moments [moments]', 'Life moments')
     .option('-c, --contract-id [contract-id]', 'Contract id')
     .option('-i, --image [image]', 'Instance image')
+    .option('-s, --sendmax [evr]', 'Maximum EVR allowed for acquiring the instance')
     .action(acquireAndDeploy);
 
 program

--- a/lib/command-handler.js
+++ b/lib/command-handler.js
@@ -243,7 +243,8 @@ async function acquire(host, options) {
             userKeys.publicKey,
             options.contractId,
             options.image,
-            appenv.hpInitCfg || {});
+            appenv.hpInitCfg || {}),
+            { sendMax: options.sendmax });
         success('Instance created!', result);
     }
     catch (e) {

--- a/lib/evernode-manager.js
+++ b/lib/evernode-manager.js
@@ -115,7 +115,15 @@ class EvernodeManager {
             config: config
         };
 
-        const result = await this.#tenantClient.acquireLease(hostAddress, requirement, { leaseOfferIndex: options.leaseIndex, transactionOptions: { sequence: options.tenantSequence } });
+        const acquireOptions = {
+            leaseOfferIndex: options.leaseIndex,
+            transactionOptions: { sequence: options.tenantSequence }
+        };
+        
+        if (options.sendMax !== undefined && options.sendMax !== null)
+            acquireOptions.sendMax = options.sendMax;
+        
+        const result = await this.#tenantClient.acquireLease(hostAddress, requirement, acquireOptions);
         const acquiredTimestamp = Date.now();
         const instanceName = result.instance.name;
 


### PR DESCRIPTION
A sendmax flag is needed to protect against frontend cached pricing or abusers.

evernodejsclient need to be changed for this to work, a pull request for that is included.